### PR TITLE
Enable canceling purchases during same shop visit

### DIFF
--- a/game.js
+++ b/game.js
@@ -7,6 +7,7 @@ const state = {
       name: "ACE Moisture Control",
       price: 120000,
       owned: false,
+      justPurchased: false,
       passive: 50000,
       description:
         "<p>Maintain pellet moisture with pinpoint accuracy, eliminating costly spec deviations and rework. ACE Moisture Control optimizes drying processes for consistent quality.</p>"
@@ -15,6 +16,7 @@ const state = {
       name: "Operator Training Suite",
       price: 120000,
       owned: false,
+      justPurchased: false,
       passive: 0,
       description:
         "<p>A comprehensive training platform designed to upskill your operators, reducing errors and downtime while enhancing operational safety and efficiency.</p>"
@@ -23,6 +25,7 @@ const state = {
       name: "Plant Solutions",
       price: 150000,
       owned: false,
+      justPurchased: false,
       passive: 0,
       description:
         "<p>Upgrade your legacy control systems to reduce faults, improve uptime, and integrate with modern analytics for smarter plant operations.</p>"
@@ -31,6 +34,7 @@ const state = {
       name: "Digital Twin & Predictive",
       price: 150000,
       owned: false,
+      justPurchased: false,
       passive: 0,
       description:
         "<p>Leverage real-time simulation and analytics to predict issues before they occur, optimizing throughput and maintenance scheduling.</p>"
@@ -39,6 +43,7 @@ const state = {
       name: "Plant Insights with OEE",
       price: 95000,
       owned: false,
+      justPurchased: false,
       passive: 0,
       description:
         "<p>Track Overall Equipment Effectiveness (OEE) with precision to identify bottlenecks, reduce downtime, and maximize asset utilization.</p>"
@@ -201,7 +206,18 @@ function updateShop() {
     card.appendChild(description);
 
     const btn = document.createElement('button');
-    if (item.owned) {
+    if (item.justPurchased) {
+      btn.className = 'cancel-btn';
+      btn.textContent = `CANCEL (+€${item.price})`;
+      btn.onclick = () => {
+        cancelSound.currentTime = 0;
+        cancelSound.play();
+        item.owned = false;
+        item.justPurchased = false;
+        state.money += item.price;
+        updateShop();
+      };
+    } else if (item.owned) {
       btn.textContent = 'Already purchased';
       btn.disabled = true;
     } else {
@@ -212,6 +228,7 @@ function updateShop() {
         cashRegisterSound.currentTime = 0;
         cashRegisterSound.play();
         item.owned = true;
+        item.justPurchased = true;
         state.money -= item.price;
         updateShop();
       };
@@ -257,6 +274,11 @@ const scenarios = [
 ];
 
 function startQuarter() {
+  Object.values(state.upgrades).forEach(u => {
+    if (u.justPurchased) {
+      u.justPurchased = false;
+    }
+  });
   applyPassiveIncome();
   quarterCounter.textContent = `Quarter ${currentQuarter}/${totalQuarters}`;
   quarterCounter.style.display = 'block';


### PR DESCRIPTION
## Summary
- add `justPurchased` state to track new buys
- allow cancelling purchases before leaving the shop
- finalize purchases only when starting a quarter

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_685d5a1a85808324a164d5a479fc8342