### PR TITLE
Update game to monthly scenarios

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-// Simplified game logic for quarterly scenarios
+// Simplified game logic for monthly scenarios
 
 const state = {
   money: 350000,
@@ -51,8 +51,8 @@ const state = {
   }
 };
 
-const totalQuarters = 4;
-let currentQuarter = 1;
+const totalMonths = 5;
+let currentMonth = 1;
 
 // DOM elements
 const shopDiv = document.getElementById("shop");
@@ -62,7 +62,7 @@ const mainGamePage = document.getElementById("main-game-page");
 const uiDiv = document.getElementById("ui");
 const catalogueBack = document.getElementById("catalogue-back");
 
-const quarterCounter = document.getElementById("quarter-counter");
+const monthCounter = document.getElementById("month-counter");
 const scenarioPage = document.getElementById("scenario-page");
 const scenarioCard = document.getElementById("scenario-card");
 const scenarioNextBtn = document.getElementById("scenario-next-btn");
@@ -180,6 +180,7 @@ function updateMoneyBar() {
 }
 
 function updateShop() {
+  monthCounter.style.display = "none";
   updateMoneyBar();
   shopDiv.innerHTML = '';
   const container = document.createElement('div');
@@ -247,7 +248,7 @@ function updateShop() {
   contBtn.className = 'catalogue-continue-btn';
   contBtn.textContent = 'Continue';
   contBtn.onclick = () => {
-    startQuarter();
+    startMonth();
   };
   shopDiv.appendChild(contBtn);
 }
@@ -296,26 +297,27 @@ const scenarios = [
       return { wins, neutrals, losses };
     }
   },
-  { text: 'Scenario 2 coming soon.', apply: () => 'No effect this quarter.' },
-  { text: 'Scenario 3 coming soon.', apply: () => 'No effect this quarter.' },
-  { text: 'Scenario 4 coming soon.', apply: () => 'No effect this quarter.' }
+  { text: 'Scenario 2 coming soon.', apply: () => 'No effect this month.' },
+  { text: 'Scenario 3 coming soon.', apply: () => 'No effect this month.' },
+  { text: 'Scenario 4 coming soon.', apply: () => 'No effect this month.' }
+  { text: 'Scenario 5 coming soon.', apply: () => 'No effect this month.' }
 ];
 
-function startQuarter() {
+function startMonth() {
   Object.values(state.upgrades).forEach(u => {
     if (u.justPurchased) {
       u.justPurchased = false;
     }
   });
   applyPassiveIncome();
-  quarterCounter.textContent = `Quarter ${currentQuarter}/${totalQuarters}`;
-  quarterCounter.style.display = 'block';
+  monthCounter.textContent = `Month ${currentMonth}/${totalMonths}`;
+  monthCounter.style.display = 'block';
   uiDiv.style.display = 'none';
   moneyBar.style.display = 'block';
   scenarioPage.style.display = 'flex';
   scenarioCard.innerHTML = '';
   
-  const scenario = scenarios[currentQuarter - 1];
+  const scenario = scenarios[currentMonth - 1];
   
   // Add title if it exists
   if (scenario.title) {
@@ -345,7 +347,7 @@ function showPerformanceReport() {
   performanceReportCard.appendChild(title);
   
   // Apply scenario effects and show results
-  const scenario = scenarios[currentQuarter - 1];
+  const scenario = scenarios[currentMonth - 1];
   const result = scenario.apply();
 
   const winsHeader = document.createElement('h3');
@@ -404,9 +406,9 @@ scenarioNextBtn.onclick = () => {
 // Performance report next button - go to catalogue
 reportNextBtn.onclick = () => {
   performanceReportPage.style.display = 'none';
-  currentQuarter++;
-  if (currentQuarter > totalQuarters) {
-    quarterCounter.style.display = 'none';
+  currentMonth++;
+  if (currentMonth > totalMonths) {
+    monthCounter.style.display = 'none';
     catalogueMusic.pause();
     mainThemeMusic.pause();
   } else {

--- a/index.html
+++ b/index.html
@@ -42,13 +42,13 @@
           <div class="character-name">Andritz representative</div>
         </div>
         <div id="catalogue-text-box">
-          <div class="text-content">This is the ANDRITZ solution portfolio. Use the arrows to navigate through it and purchase the solutions you desire. Click "Finish Selection" once you are done with your purchases.</div>
+          <div class="text-content">This is the ANDRITZ solution portfolio. Select the solutions you wish to purchase by clicking the BUY buttons below each option. When you're ready, click "Continue" to proceed.</div>
         </div>
       </div>
     </div>
     <img id="catalogue-back" src="assets/icons/undo.svg" alt="Back" style="display:none;">
   </div>
-  <div id="quarter-counter" style="display:none;">Quarter 1/4</div>
+  <div id="month-counter" style="display:none;">Month 1/5</div>
   <div id="scenario-page" style="display:none;">
     <div id="scenario-card" class="shop-card catalogue-card"></div>
     <button id="scenario-next-btn" class="catalogue-continue-btn">Next</button>
@@ -56,7 +56,7 @@
 
   <div id="performance-report-page" style="display:none;">
     <div id="performance-report-card" class="shop-card catalogue-card"></div>
-    <button id="report-next-btn" class="catalogue-continue-btn">Continue to Catalogue</button>
+    <button id="report-next-btn" class="catalogue-continue-btn">Continue</button>
   </div>
 
   <div id="performance-report-container" style="display:none;"></div>

--- a/style.css
+++ b/style.css
@@ -742,16 +742,6 @@ h1 {
     opacity: 0.5;
 }
 
-#month-counter {
-    position: fixed;
-    top: 20px;
-    left: 20px;
-    color: white;
-    font-family: 'Press Start 2P', cursive;
-    font-size: 0.7rem;
-    z-index: 1000;
-    text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.7);
-}
 
 #scenario-counter {
     position: fixed;
@@ -1114,8 +1104,8 @@ body.end-year-scene #points-counter {
     filter: invert(1);
 }
 
-/* Quarter counter */
-#quarter-counter {
+/* Month counter */
+#month-counter {
     position: fixed;
     top: 20px;
     left: 20px;


### PR DESCRIPTION
## Summary
- update catalogue instructions
- rename quarter counter to month counter and increment for 5 months
- hide the month counter when in catalogue
- rename scenario cycle variables to use months
- add placeholder for a fifth scenario

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e53546f6c83248c1f001777dd52ba