### PR TITLE
Adjust month transition timing

### DIFF
--- a/game.js
+++ b/game.js
@@ -384,9 +384,11 @@ function showMonthTransition(callback) {
   }
   monthTransition.style.display = 'flex';
   monthTransitionImages.forEach(img => (img.style.opacity = 0));
-  monthTransitionText.style.opacity = 0;
+  // Display the transition text for the entire animation
+  monthTransitionText.style.opacity = 1;
 
-  const stepDuration = 800; // ~0.8s per slide for ~4s total
+  // Show each image for ~2 seconds with a slower cross fade
+  const stepDuration = 2000;
   let index = 0;
 
   const next = () => {
@@ -400,13 +402,13 @@ function showMonthTransition(callback) {
       index++;
       setTimeout(next, stepDuration);
     } else {
-      monthTransitionText.style.opacity = 1;
+      // Fade out the overlay and text after the last slide
+      monthTransitionText.style.opacity = 0;
       setTimeout(() => {
         monthTransition.style.display = 'none';
         monthTransitionImages.forEach(img => (img.style.opacity = 0));
-        monthTransitionText.style.opacity = 0;
         if (callback) callback();
-      }, stepDuration);
+      }, 500);
     }
   };
 

--- a/style.css
+++ b/style.css
@@ -1158,7 +1158,8 @@ body.end-year-scene #points-counter {
     height: 100%;
     object-fit: cover;
     opacity: 0;
-    transition: opacity 0.8s linear;
+    /* Slower cross fade between images */
+    transition: opacity 2s linear;
 }
 
 #month-transition .transition-text {
@@ -1167,5 +1168,6 @@ body.end-year-scene #points-counter {
     font-size: 1.2rem;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.7);
     opacity: 0;
-    transition: opacity 0.8s linear;
+    /* Slightly faster fade for text */
+    transition: opacity 0.5s linear;
 }


### PR DESCRIPTION
## Summary
- show transition text for entire month change
- slow down month transition crossfade and adjust timing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e6b4475b48324a0fac211e4471da6