### PR TITLE
Reflect windfall scenario in performance report

### DIFF
--- a/game.js
+++ b/game.js
@@ -346,6 +346,10 @@ const scenarios = [
       const neutrals = [];
       const losses = [];
 
+      // The large rush order brings in an immediate bonus
+      state.money += 200000;
+      wins.push('Large order: +200k');
+
       if (state.upgrades.moisture.owned) {
         state.money += 50000;
         wins.push('Dryer ACE: +50k');


### PR DESCRIPTION
## Summary
- handle the unexpected windfall scenario by adding 200k to the player's money
- list `Large order: +200k` as a win

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e94f1134083248d65f0b1918cbfaa