### PR TITLE
Fix missing month transition image

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
     <img src="assets/slide backgrounds/bg2.png" alt="Slide 2">
     <img src="assets/slide backgrounds/bg3.png" alt="Slide 3">
     <img src="assets/slide backgrounds/bg4.png" alt="Slide 4">
+    <img src="assets/slide backgrounds/bg5.png" alt="Slide 5">
     <div class="transition-text">A month is passing...</div>
   </div>
 


### PR DESCRIPTION
## Summary
- include `bg5.png` slide in month transition so final month shows correctly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e993886048324af2c440076d54333