### PR TITLE
Update month 3 rewards

### DIFF
--- a/game.js
+++ b/game.js
@@ -355,6 +355,18 @@ const scenarios = [
         state.money += 80000;
         wins.push('Plant automation upgrade: +80k');
       }
+      if (state.upgrades.training.owned) {
+        state.money += 10000;
+        wins.push('Operator Training Suite: +10k');
+      }
+      if (state.upgrades.digitalTwin.owned) {
+        state.money += 10000;
+        wins.push('Asset management: +10k');
+      }
+      if (state.upgrades.plantInsights.owned) {
+        state.money += 10000;
+        wins.push('Plant Insights with OEE: +10k');
+      }
       return { wins, neutrals, losses };
     }
   },


### PR DESCRIPTION
## Summary
- give Operator Training Suite, Asset management and Plant Insights with OEE a 10k bonus during the month 3 scenario

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d00f15c8324a89123a44b331eed