### PR TITLE
Add monthly production efficiency bonus

### DIFF
--- a/game.js
+++ b/game.js
@@ -574,6 +574,10 @@ function showPerformanceReport() {
   const scenario = scenarios[currentMonth - 1];
   const result = scenario.apply();
 
+  // Global monthly bonus
+  state.money += 100000;
+  result.wins.push('Production efficiency: +100k');
+
   const winsHeader = document.createElement('h3');
   winsHeader.textContent = 'WINS';
   winsHeader.className = 'report-section-header win';


### PR DESCRIPTION
## Summary
- update performance report logic
- add production efficiency bonus to wins every month

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_685ea218802083248ed7c76afaed0307