### PR TITLE
Add rules page before first shop

### DIFF
--- a/game.js
+++ b/game.js
@@ -63,6 +63,8 @@ const uiDiv = document.getElementById("ui");
 const catalogueBack = document.getElementById("catalogue-back");
 
 const monthCounter = document.getElementById("month-counter");
+const rulesPage = document.getElementById("rules-page");
+const rulesNextBtn = document.getElementById("rules-next-btn");
 const scenarioPage = document.getElementById("scenario-page");
 const scenarioCard = document.getElementById("scenario-card");
 const scenarioNextBtn = document.getElementById("scenario-next-btn");
@@ -170,13 +172,11 @@ function nextDialogue() {
     dialogueIndex++;
   } else {
     mainGamePage.style.display = 'none';
-    uiDiv.style.display = 'block';
-    moneyBar.style.display = 'block';
+    rulesPage.style.display = 'flex';
     mainGamePage.removeEventListener('click', nextDialogue);
     mainThemeMusic.pause();
     catalogueMusic.volume = 0.1;
     catalogueMusic.play();
-    updateShop();
   }
 }
 
@@ -639,6 +639,14 @@ function showPerformanceReport() {
 
   updateMoneyBar();
 }
+
+// Rules page next button - go to shop
+rulesNextBtn.onclick = () => {
+  rulesPage.style.display = 'none';
+  uiDiv.style.display = 'block';
+  moneyBar.style.display = 'block';
+  updateShop();
+};
 
 // Scenario page next button - go to performance report
 scenarioNextBtn.onclick = () => {

--- a/index.html
+++ b/index.html
@@ -49,6 +49,23 @@
     <img id="catalogue-back" src="assets/icons/undo.svg" alt="Back" style="display:none;">
   </div>
   <div id="month-counter" style="display:none;">Month 1/5</div>
+  <div id="rules-page" style="display:none;">
+    <div id="rules-card" class="shop-card catalogue-card incident-card">
+      <img class="card-signet" src="assets/icons/signet.png" alt="ANDRITZ">
+      <h2>Game rules</h2>
+      <p class="rules-body">You’re responsible for making strategic investments to prepare your plant for operational disruptions. Starting with $300,000, choose from a range of AD solutions to support your strategy.</p>
+      <h3 class="rules-subheader">How it works</h3>
+      <ul class="rules-list">
+        <li>The simulation spans five months.</li>
+        <li>Each month presents a scenario impacting operations.</li>
+        <li>Your product choices influence gains, penalties, and losses.</li>
+        <li>Additional investment rounds will occur.</li>
+      </ul>
+      <h3 class="rules-subheader">Your goal</h3>
+      <p class="rules-body">Minimize disruption losses, improve performance, and finish with the highest possible balance.</p>
+    </div>
+    <button id="rules-next-btn" class="catalogue-continue-btn">Continue</button>
+  </div>
   <div id="scenario-page" style="display:none;">
     <div id="scenario-card" class="shop-card catalogue-card"></div>
     <button id="scenario-next-btn" class="catalogue-continue-btn">Next</button>

--- a/style.css
+++ b/style.css
@@ -1148,6 +1148,51 @@ body.end-year-scene #points-counter {
     margin-top: 60px;
 }
 
+/* Rules page layout */
+#rules-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    margin-top: 60px;
+}
+#rules-page .catalogue-card {
+    width: 700px;
+    height: 800px;
+}
+#rules-page .catalogue-card h2 {
+    color: #0075be;
+    font-family: 'Press Start 2P', cursive;
+    font-size: 1rem;
+    margin-top: 10px;
+    margin-bottom: 20px;
+    text-align: center;
+    line-height: 1.4;
+}
+#rules-page .rules-body {
+    font-size: 1rem;
+    line-height: 1.5;
+    text-align: left;
+    margin-bottom: 20px;
+}
+#rules-page .rules-subheader {
+    color: #0075be;
+    font-family: 'Press Start 2P', cursive;
+    font-size: 0.9rem;
+    margin-bottom: 10px;
+    text-align: center;
+}
+#rules-page .rules-list {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    margin-left: 20px;
+    margin-bottom: 20px;
+    text-align: left;
+}
+#rules-page .rules-list li {
+    margin-bottom: 8px;
+}
+
 /* Performance Report Page Layout */
 #performance-report-page {
     display: flex;


### PR DESCRIPTION
## Summary
- insert a "Game rules" page after the intro dialogue
- style the new page to match incident card layout
- show the page after dialogue and continue to the shop when clicking Continue

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ea9b07d3483248ee289062ca204b7